### PR TITLE
fix(api/check): change insert query

### DIFF
--- a/webapp/pages/api/check.ts
+++ b/webapp/pages/api/check.ts
@@ -16,7 +16,9 @@ export default async function handler(
   const database = await openDb();
 
   if (req.method === "POST") {
-    await database.exec(`INSERT INTO Plagiarism (text) VALUES ("${req.body}")`);
+    const reqText = req.body.replace(/"/g, '""');
+
+    await database.exec(`INSERT INTO Plagiarism (text) VALUES ("${reqText}")`);
     res.status(200).json({ status: 200, message: "File sent" });
   } else if (req.method === "GET") {
     /*** SEND TEXT (req.body) TO THE NEURAL NET ***/


### PR DESCRIPTION
Replace all '"' to '""' of request body text because it was causing a bug where a text with some '"' would cause the query to crash because it would not be scaped.